### PR TITLE
GitHub: só executa release se estivermos no repositório principal

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -37,7 +37,9 @@ jobs:
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
 
+    # Make development build step only runs if the repo matches the specified one
     - name: Make development build
+      if: github.repository == 'lucca-pellegrini/aeds3'
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"

--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -34,7 +34,9 @@ jobs:
     - name: Build with Maven
       run: mvn -B package --file pom.xml
 
+    # Make release build step only runs if the repo matches the specified one
     - name: Make release build
+      if: github.repository == 'lucca-pellegrini/aeds3'
       uses: "marvinpinto/action-automatic-releases@latest"
       with:
         repo_token: "${{ secrets.PERSONAL_ACCESS_TOKEN }}"


### PR DESCRIPTION
Por exigir o uso de um Personal Access Token (PAT) do GitHub, que deve ser configurado ao inicializar o repositório remoto no GitHub, esses workflows não funcionam em forks que não têm essa configuração. Por se tratar de um trabalho colaborativo, e por não ser necessário que o fork de cada um tenha seus próprios releases automáticos, convém limitar esses workflows ao repositório original. Resolve #7.